### PR TITLE
refactor: refactor bad smell ToArrayCallWithZeroLengthArrayArgument

### DIFF
--- a/seatunnel-connectors-v2/connector-elasticsearch/src/main/java/org/apache/seatunnel/connectors/seatunnel/elasticsearch/source/ElasticsearchSource.java
+++ b/seatunnel-connectors-v2/connector-elasticsearch/src/main/java/org/apache/seatunnel/connectors/seatunnel/elasticsearch/source/ElasticsearchSource.java
@@ -71,7 +71,7 @@ public class ElasticsearchSource implements SeaTunnelSource<SeaTunnelRow, Elasti
                 SeaTunnelDataType seaTunnelDataType = EsTypeMappingSeaTunnelType.getSeaTunnelDataType(esType);
                 fieldTypes[i] = seaTunnelDataType;
             }
-            rowTypeInfo = new SeaTunnelRowType(source.toArray(new String[source.size()]), fieldTypes);
+            rowTypeInfo = new SeaTunnelRowType(source.toArray(new String[0]), fieldTypes);
         }
     }
 

--- a/seatunnel-connectors-v2/connector-kudu/src/main/java/org/apache/seatunnel/connectors/seatunnel/kudu/source/KuduSource.java
+++ b/seatunnel-connectors-v2/connector-kudu/src/main/java/org/apache/seatunnel/connectors/seatunnel/kudu/source/KuduSource.java
@@ -177,6 +177,6 @@ public class KuduSource implements SeaTunnelSource<SeaTunnelRow, KuduSourceSplit
             log.warn("get row type info exception", e);
             throw new PrepareFailException("kudu", PluginType.SOURCE, e.toString());
         }
-        return new SeaTunnelRowType(fieldNames.toArray(new String[fieldNames.size()]), seaTunnelDataTypes.toArray(new SeaTunnelDataType<?>[seaTunnelDataTypes.size()]));
+        return new SeaTunnelRowType(fieldNames.toArray(new String[0]), seaTunnelDataTypes.toArray(new SeaTunnelDataType<?>[0]));
     }
 }


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## ToArrayCallWithZeroLengthArrayArgument
The performance of the empty array version is the same, and sometimes even better, compared
to the pre-sized version. Also, passing a pre-sized array is dangerous for a concurrent or
synchronized collection as a data race is possible between the <code>size</code> and <code>toArray</code>
calls. This may result in extra <code>null</code>s at the end of the array if the collection was concurrently
shrunk during the operation.</p>
See https://shipilev.net/blog/2016/arrays-wisdom-ancients/ for more details.

<!-- fingerprint:-1281504864 -->
<!-- fingerprint:-1710110187 -->
<!-- fingerprint:-1710110187 -->
# Repairing Code Style Issues
* ToArrayCallWithZeroLengthArrayArgument (3)
