### PR TITLE
refactor: refactor bad smell InnerClassMayBeStatic

### DIFF
--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/source/reader/fetch/MySqlSourceFetchTaskContext.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/source/reader/fetch/MySqlSourceFetchTaskContext.java
@@ -26,6 +26,7 @@ import org.apache.seatunnel.connectors.cdc.base.relational.JdbcSourceEventDispat
 import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
 import org.apache.seatunnel.connectors.cdc.base.source.reader.external.JdbcSourceFetchTaskContext;
 import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+import org.apache.seatunnel.connectors.cdc.debezium.EmbeddedDatabaseHistory;
 import org.apache.seatunnel.connectors.seatunnel.cdc.mysql.config.MySqlSourceConfig;
 import org.apache.seatunnel.connectors.seatunnel.cdc.mysql.source.offset.BinlogOffset;
 import org.apache.seatunnel.connectors.seatunnel.cdc.mysql.utils.MySqlUtils;
@@ -51,6 +52,7 @@ import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
+import io.debezium.relational.history.TableChanges;
 import io.debezium.schema.DataCollectionId;
 import io.debezium.schema.TopicSelector;
 import io.debezium.util.Collect;
@@ -60,6 +62,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -83,15 +86,18 @@ public class MySqlSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
     private ChangeEventQueue<DataChangeEvent> queue;
     private MySqlErrorHandler errorHandler;
 
+    private Collection<TableChanges.TableChange> engineHistory;
     public MySqlSourceFetchTaskContext(
         JdbcSourceConfig sourceConfig,
         JdbcDataSourceDialect dataSourceDialect,
         MySqlConnection connection,
-        BinaryLogClient binaryLogClient) {
+        BinaryLogClient binaryLogClient,
+        Collection<TableChanges.TableChange> engineHistory) {
         super(sourceConfig, dataSourceDialect);
         this.connection = connection;
         this.binaryLogClient = binaryLogClient;
         this.metadataProvider = new MySqlEventMetadataProvider();
+        this.engineHistory = engineHistory;
     }
 
     @Override
@@ -100,7 +106,11 @@ public class MySqlSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
         final MySqlConnectorConfig connectorConfig = getDbzConnectorConfig();
         final boolean tableIdCaseInsensitive = connection.isTableIdCaseSensitive();
         this.topicSelector = MySqlTopicSelector.defaultSelector(connectorConfig);
-
+        EmbeddedDatabaseHistory.registerHistory(
+            sourceConfig
+                .getDbzConfiguration()
+                .getString(EmbeddedDatabaseHistory.DATABASE_HISTORY_INSTANCE_NAME),
+            engineHistory);
         this.databaseSchema =
             MySqlUtils.createMySqlDatabaseSchema(connectorConfig, tableIdCaseInsensitive);
         this.offsetContext =
@@ -225,13 +235,12 @@ public class MySqlSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
      * Loads the connector's persistent offset (if present) via the given loader.
      */
     private MySqlOffsetContext loadStartingOffsetState(
-        OffsetContext.Loader loader, SourceSplitBase mySqlSplit) {
+        MySqlOffsetContext.Loader loader, SourceSplitBase mySqlSplit) {
         Offset offset =
             mySqlSplit.isSnapshotSplit() ? BinlogOffset.INITIAL_OFFSET
                 : mySqlSplit.asIncrementalSplit().getStartupOffset();
 
-        MySqlOffsetContext mySqlOffsetContext =
-            (MySqlOffsetContext) loader.load(offset.getOffset());
+        MySqlOffsetContext mySqlOffsetContext = loader.load(offset.getOffset());
 
         if (!isBinlogAvailable(mySqlOffsetContext)) {
             throw new IllegalStateException(
@@ -277,7 +286,7 @@ public class MySqlSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
     /**
      * A subclass implementation of {@link MySqlTaskContext} which reuses one BinaryLogClient.
      */
-    public class MySqlTaskContextImpl extends MySqlTaskContext {
+    public static class MySqlTaskContextImpl extends MySqlTaskContext {
 
         private final BinaryLogClient reusedBinaryLogClient;
 


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## InnerClassMayBeStatic
Inner classes that do not reference their enclosing instances can be made static.
This prevents a common cause of memory leaks and uses less memory per instance of the class.

<!-- fingerprint:534171792 -->
# Repairing Code Style Issues
* InnerClassMayBeStatic (1)
